### PR TITLE
Fix bad version constraints in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,11 @@
 	},
 	"require": {
 		"php": "^7.3",
-		"symfony/framework-bundle": "^5.0.6",
-		"symfony/security-bundle": "^5.0.6",
-		"symfony/form": "^5.0.6",
-		"phpunit/phpunit": "^9.0.1",
-		"doctrine/orm": "^2.7.2"
+		"symfony/framework-bundle": "^5.0",
+		"symfony/security-bundle": "^5.0",
+		"symfony/form": "^5.0",
+		"symfony/phpunit-bridge": "^5.0",
+		"doctrine/orm": "^2.7"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Fixes #13 

**Changes proposed in this pull request:**

* Replace `^x.y.z` to `^x.y`.

**Possible side effects:**

* Security breach caused by older dependencies.

**Alternatives to the proposals**

Update @GothShoot's project.